### PR TITLE
FIX: El mail usach es .cl no .com

### DIFF
--- a/www/app/um_acercade.html
+++ b/www/app/um_acercade.html
@@ -31,7 +31,7 @@
 		
 		<h2>Agradecimentos</h2>
 		<p>La funcionalidad de Salas USACH usa tecnologías desarrolladas por <b>Felipe Garay</b>.</p>
-		felipe.garay[at]usach[dot]com</br>
+		felipe.garay[at]usach[dot]cl</br>
 		<a href="http://salasusach.herokuapp.com">http://salasusach.herokuapp.com</a>
     </center>
 	</ion-content>


### PR DESCRIPTION
Se arregla un pequeño error con respecto al correo electrónico usach de Felipe Garay
